### PR TITLE
Fix Nil deserialization

### DIFF
--- a/src/main/scala/com/romix/scala/serialization/kryo/ScalaKryo.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/ScalaKryo.scala
@@ -29,6 +29,14 @@ class ScalaKryo(classResolver: ClassResolver, referenceResolver: ReferenceResolv
 
   lazy val objSer = new ObjectSerializer[AnyRef]
 
+  override def getDefaultSerializer(`type`: Class[_]): Serializer[_] = {
+    if(isSingleton(`type`)) {
+      objSer
+    } else {
+      super.getDefaultSerializer(`type`)
+    }
+  }
+
   override def newDefaultSerializer(klass: Class[_]): Serializer[_] = {
     if (isSingleton(klass)) {
       objSer

--- a/src/test/scala/com/romix/scala/serialization/kryo/ScalaKryoTest.scala
+++ b/src/test/scala/com/romix/scala/serialization/kryo/ScalaKryoTest.scala
@@ -1,0 +1,17 @@
+package com.romix.scala.serialization.kryo
+
+import com.esotericsoftware.kryo.util.{DefaultClassResolver, DefaultStreamFactory, ListReferenceResolver}
+import org.scalatest.Outcome
+
+class ScalaKryoTest extends SpecCase {
+  kryo = new ScalaKryo(new DefaultClassResolver(), new ListReferenceResolver(), new DefaultStreamFactory())
+
+  "ScalaKryo" should "preserve Nil equality" in {
+    val deserializedNil = roundTrip(1, Nil)
+    assert(deserializedNil eq Nil)
+  }
+
+  override def withFixture(test: NoArgTest): Outcome = {
+    test()
+  }
+}


### PR DESCRIPTION
Override getDefaultSerializer to ensure that modules are serialized with the ObjectSerializer even if a different default serializer covers the  type. This fixes issues with equality between Nil and Kryo deserialized Nil.

Fixes #37