### PR TITLE
Update the dependecies in preparation for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ How to use this library in your project
 To use this serializer, you need to do two things:
 *   Include a dependency on this library into your project:
 
-	`libraryDependencies += "com.github.romix.akka" % "akka-kryo-serialization" % "0.3.2"`
+	`libraryDependencies += "com.github.romix.akka" % "akka-kryo-serialization" % "0.3.3"`
     
 *   Add some new elements to your Akka configuration file, e.g. `application.conf`
 
@@ -49,7 +49,7 @@ To use the official release of akka-kryo-serialization, please use the following
     <dependency>
         <groupId>com.github.romix.akka</groupId>
         <artifactId>akka-kryo-serialization_2.10</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.3</version>
     </dependency>
 ```
 
@@ -71,7 +71,7 @@ If you want to test the latest snapshot of this library, please use the followin
 
 For your SBT project files, you can use the following coordinates:
 
-    "com.github.romix.akka" %% "akka-kryo-serialization" % "0.3.2"
+    "com.github.romix.akka" %% "akka-kryo-serialization" % "0.3.3"
     
 
 How do I build this library on my own?

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,7 @@ import com.typesafe.sbt.osgi.SbtOsgi.{ OsgiKeys, osgiSettings, defaultOsgiSettin
 
 object MinimalBuild extends Build {
 
-  lazy val buildVersion = "0.3.2"
+  lazy val buildVersion = "0.3.3"
 
   lazy val typesafe = "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   lazy val typesafeSnapshot = "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
@@ -33,23 +33,23 @@ object MinimalBuild extends Build {
     resolvers += typesafeSnapshot,
     resolvers += sonatypeSnapshot,
     // publishArtifact in packageDoc := false,
-    crossScalaVersions := Seq("2.10.4","2.11.2"),
-    scalaVersion := "2.10.4",
-    libraryDependencies += "com.typesafe.akka" %% "akka-remote" % "2.3.3",
-    libraryDependencies += "com.typesafe.akka" %% "akka-kernel" % "2.3.3",
-    libraryDependencies += "com.esotericsoftware.kryo" % "kryo" % "2.24.0",
-    libraryDependencies += "net.jpountz.lz4" % "lz4" % "1.2.0",
+    crossScalaVersions := Seq("2.10.4","2.11.5"),
+    scalaVersion := "2.11.5",
+    libraryDependencies += "com.typesafe.akka" %% "akka-remote" % "2.3.9",
+    libraryDependencies += "com.typesafe.akka" %% "akka-kernel" % "2.3.9",
+    libraryDependencies += "com.esotericsoftware" % "kryo" % "3.0.0",
+    libraryDependencies += "net.jpountz.lz4" % "lz4" % "1.3.0",
 
     libraryDependencies ++= {
       val sv = scalaVersion.value
       CrossVersion.partialVersion(sv) match {
         case Some((2, scalaMajor)) if scalaMajor >= 11 =>
           Seq(
-            "org.scalatest"  % "scalatest_2.11" % "2.2.0" % "test"
+            "org.scalatest"  % "scalatest_2.11" % "2.2.1" % "test"
           )
         case Some((2, scalaMajor)) if scalaMajor >= 10 =>
           Seq(
-            "org.scalatest" % "scalatest_2.10" % "2.2.0" % "test"
+            "org.scalatest" % "scalatest_2.10" % "2.2.1" % "test"
           )
       }
     },
@@ -69,7 +69,7 @@ object MinimalBuild extends Build {
       "-feature",
       "-unchecked",
       "-deprecation",
-      "-target:jvm-1.6",
+      "-target:jvm-1.7",
       "-language:existentials",
       "-optimise",
       "-Xlog-reflective-calls"
@@ -116,10 +116,10 @@ object MinimalBuild extends Build {
         "com.romix.akka.serialization.kryo",
         "com.romix.scala.serialization.kryo"),
       OsgiKeys.exportPackage := Seq(
-        "com.romix.akka.serialization.kryo;version=\"0.3.2\"",
-        "com.romix.scala.serialization.kryo;version=\"0.3.2\""),
+        "com.romix.akka.serialization.kryo;version=\"0.3.3\"",
+        "com.romix.scala.serialization.kryo;version=\"0.3.3\""),
       OsgiKeys.importPackage := Seq(
-        "com.esotericsoftware.*;version=\"[2.24.0,3.0.0)\"",
+        "com.esotericsoftware.*;version=\"[3.0.0,3.1.0)\"",
         "com.typesafe.config;version=\"[1.2.0,1.3.0)\"",
         "akka*;version=\"[2.3.0,3.4.0)\"",
         "scala*;version=\"[2.10.0,2.12)\"",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7


### PR DESCRIPTION
Bumped all dependencies to the latest released versions.
Also moved to JVM 1.7 bytecode generation in order to match LZ4-Java.
Moved updated also the OSGI definitions.
Bumped the version to 0.3.3 in all the places