### PR TITLE
Fix OSGi headers and clean up indenting.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,9 +16,9 @@
 
 import sbt._
 import Keys._
-import com.typesafe.sbt.osgi.SbtOsgi.{ OsgiKeys, osgiSettings, defaultOsgiSettings }
+import com.typesafe.sbt.osgi._
 
-object MinimalBuild extends Build {
+object Build extends sbt.Build {
 
   lazy val buildVersion = "0.4.0"
 
@@ -60,12 +60,12 @@ object MinimalBuild extends Build {
     javaOptions in run += "-XX:+UseAES -XX:+UseAESIntrinsics",
 
     publishTo := {
-	val nexus = "https://oss.sonatype.org/"
-	if (buildVersion.trim.endsWith("SNAPSHOT"))
-	    Some("snapshots" at nexus + "content/repositories/snapshots")
-	else
-	    Some("releases" at nexus + "service/local/staging/deploy/maven2")
-	},
+      val nexus = "https://oss.sonatype.org/"
+      if (buildVersion.trim.endsWith("SNAPSHOT"))
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    },
 
     publishMavenStyle := true,
 
@@ -73,42 +73,28 @@ object MinimalBuild extends Build {
 
     pomIncludeRepository := { _ => false },
 
-    pomExtra := (
-  <url>https://github.com/romix/akka-kryo-serialization</url>
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:romix/akka-kryo-serialization.git</url>
-    <connection>scm:git:git@github.com:romix/akka-kryo-serialization.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>romix</id>
-      <name>Roman Levenstein</name>
-      <email>romixlev@gmail.com</email>
-    </developer>
-  </developers>
-    ))
-    .settings(defaultOsgiSettings: _*)
+    pomExtra := <url>https://github.com/romix/akka-kryo-serialization</url>
+      <licenses>
+        <license>
+          <name>The Apache Software License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+      <scm>
+        <url>git@github.com:romix/akka-kryo-serialization.git</url>
+        <connection>scm:git:git@github.com:romix/akka-kryo-serialization.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <id>romix</id>
+          <name>Roman Levenstein</name>
+          <email>romixlev@gmail.com</email>
+        </developer>
+      </developers>)
+    .settings(SbtOsgi.osgiSettings: _*)
     .settings(
-      OsgiKeys.privatePackage := Seq(
-        "com.romix.akka.serialization.kryo",
-        "com.romix.scala.serialization.kryo"),
-      OsgiKeys.exportPackage := Seq(
-        "com.romix.akka.serialization.kryo;version=\"0.4.0\"",
-        "com.romix.scala.serialization.kryo;version=\"0.4.0\""),
-      OsgiKeys.importPackage := Seq(
-        "com.esotericsoftware.*;version=\"[3.0.0,3.1.0)\"",
-        "com.typesafe.config;version=\"[1.2.0,1.3.0)\"",
-        "akka*;version=\"[2.4.0,3.4.0)\"",
-        "scala*;version=\"[2.11.0,2.12)\"",
-        "scala*;version=\"[2.11.0,2.12)\"",
-        "net.jpountz.lz4;resolution:=optional"
-        )
+      OsgiKeys.privatePackage := Nil,
+      OsgiKeys.exportPackage := Seq("com.romix.*")
     )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,15 +20,12 @@ import com.typesafe.sbt.osgi._
 
 object Build extends sbt.Build {
 
-  lazy val buildVersion = "0.4.0"
-
   lazy val typesafe = "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   lazy val typesafeSnapshot = "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
   lazy val sonatypeSnapshot = "Sonatype Snapshots Repository" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
   lazy val root = Project(id = "akka-kryo-serialization", base = file(".")).settings(
 
-    version := buildVersion,
     organization := "com.github.romix.akka",
     resolvers += typesafe,
     resolvers += typesafeSnapshot,
@@ -61,7 +58,7 @@ object Build extends sbt.Build {
 
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (buildVersion.trim.endsWith("SNAPSHOT"))
+      if (version.value.trim.endsWith("SNAPSHOT"))
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases" at nexus + "service/local/staging/deploy/maven2")


### PR DESCRIPTION
The OSGi headers are not in the currently deployed artifacts. I'm not exactly sure why. I believe it has to do with using `defaultOsgiSettings` instead of `osgiSettings`. If you cut off the head of a chicken and slowly pour the blood over your display, you will see the difference in these two keys.

[`bnd`](http://bnd.bndtools.org) (the backend of all OSGi bundle plugins) works better when you let it work from defaults. It's a really smart tool.

Lastly, I just cleaned up formatting stuff.

Hope that all helps! :)