### PR TITLE
Serializer for Akka's ByteString

### DIFF
--- a/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializer.scala
+++ b/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializer.scala
@@ -198,7 +198,7 @@ class KryoSerializer(val system: ExtendedActorSystem) extends Serializer {
   locally {
     log.debug("Got max-buffer-size: {}", maxBufferSize)
   }
-  
+
   val serializerPoolSize = settings.SerializerPoolSize
 
   val idStrategy = settings.IdStrategy
@@ -393,6 +393,7 @@ class KryoSerializer(val system: ExtendedActorSystem) extends Serializer {
     kryo.addDefaultSerializer(classOf[scala.collection.generic.MapFactory[scala.collection.Map]], classOf[ScalaImmutableMapSerializer])
     kryo.addDefaultSerializer(classOf[scala.collection.generic.SetFactory[scala.collection.Set]], classOf[ScalaImmutableSetSerializer])
 
+    kryo.addDefaultSerializer(classOf[akka.util.ByteString], classOf[AkkaByteStringSerializer])
     kryo.addDefaultSerializer(classOf[scala.collection.Traversable[_]], classOf[ScalaCollectionSerializer])
     kryo.addDefaultSerializer(classOf[ActorRef], new ActorRefSerializer(system))
 
@@ -475,7 +476,7 @@ class KryoSerializer(val system: ExtendedActorSystem) extends Serializer {
  * Kryo-based serializer backend
  */
 class KryoBasedSerializer(
-    val kryo: Kryo, 
+    val kryo: Kryo,
     val bufferSize: Int,
     val maxBufferSize: Int,
     val bufferPoolSize: Int,

--- a/src/main/scala/com/romix/scala/serialization/kryo/AkkaByteStringSerializer.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/AkkaByteStringSerializer.scala
@@ -24,7 +24,7 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
-import akka.util.{ByteString, ByteStringBuilder}
+import akka.util.ByteString
 
 /**
  * *
@@ -38,9 +38,7 @@ class AkkaByteStringSerializer() extends Serializer[ByteString] {
 
   override def read(kryo: Kryo, input: Input, typ: Class[ByteString]): ByteString = {
     val len = input.readInt(true)
-    val builder = new ByteStringBuilder
-    builder ++= input.readBytes(len)
-    builder.result
+    ByteString(input.readBytes(len))
   }
 
   override def write(kryo: Kryo, output: Output, obj: ByteString) = {

--- a/src/main/scala/com/romix/scala/serialization/kryo/AkkaByteStringSerializer.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/AkkaByteStringSerializer.scala
@@ -1,0 +1,52 @@
+/**
+ * *****************************************************************************
+ * Copyright 2012 Roman Levenstein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ****************************************************************************
+ */
+
+package com.romix.scala.serialization.kryo
+
+import scala.collection.Traversable
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.Serializer
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import akka.util.{ByteString, ByteStringBuilder}
+
+/**
+ * *
+ *
+ * Generic serializer for traversable collections
+ *
+ * @author luben
+ *
+ */
+class AkkaByteStringSerializer() extends Serializer[ByteString] {
+
+  override def read(kryo: Kryo, input: Input, typ: Class[ByteString]): ByteString = {
+    val len = input.readInt(true)
+    val builder = new ByteStringBuilder
+    builder ++= input.readBytes(len)
+    builder.result
+  }
+
+  override def write(kryo: Kryo, output: Output, obj: ByteString) = {
+    val len = obj.size
+    output.writeInt(len, true)
+    obj.foreach { output.writeByte(_) }
+  }
+}
+

--- a/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
+++ b/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
@@ -1,0 +1,59 @@
+package com.romix.akka.serialization.kryo
+
+import akka.actor.ActorSystem
+import akka.serialization.SerializationExtension
+import akka.util.ByteString
+import com.esotericsoftware.kryo.util.{DefaultClassResolver, DefaultStreamFactory, ListReferenceResolver}
+import com.romix.scala.serialization.kryo.{ScalaKryo, SpecCase}
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{WordSpecLike, Matchers, FlatSpec, Outcome}
+
+class ByteStringTest extends WordSpecLike with Matchers {
+  val system = ActorSystem("example", ConfigFactory.parseString(
+    """
+    akka {
+      loglevel = "DEBUG"
+      actor {
+	kryo {
+	  trace = true
+	  idstrategy = "default"
+	  implicit-registration-logging = true
+	  post-serialization-transformations = off
+	}
+        serializers {
+          kryo = "com.romix.akka.serialization.kryo.KryoSerializer"
+        }
+	serialization-bindings {
+	  "akka.util.ByteString$ByteString1C" = kryo
+	  "akka.util.ByteString" = kryo
+	  "scala.collection.immutable.Vector" = kryo
+	}
+      }
+    }
+    """))
+
+  val serialization = SerializationExtension(system)
+
+  "ScalaKryo" should {
+    def test(obj: AnyRef): Unit = {
+      val serializer = serialization.findSerializerFor(obj)
+      Console.println("Object of class " + obj.getClass.getName + " got serializer of class " + serializer.getClass.getName)
+      serializer.getClass.equals(classOf[KryoSerializer]) should be(true)
+      // Check serialization/deserialization
+      val serialized = serialization.serialize(obj)
+      serialized.isSuccess should be(true)
+
+      val deserialized = serialization.deserialize(serialized.get, obj.getClass)
+      deserialized.isSuccess should be(true)
+      deserialized.get.equals(obj) should be(true)
+    }
+
+    "handle Vectors" in {
+      test(Vector("foo"))
+    }
+
+    "handle compact ByteStrings" in {
+      test(ByteString("foo").compact)
+    }
+  }
+}

--- a/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
+++ b/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
@@ -12,7 +12,6 @@ class ByteStringTest extends WordSpecLike with Matchers {
   val system = ActorSystem("example", ConfigFactory.parseString(
     """
     akka {
-      loglevel = "DEBUG"
       actor {
 	kryo {
 	  trace = true

--- a/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
+++ b/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
@@ -36,15 +36,16 @@ class ByteStringTest extends WordSpecLike with Matchers {
   "ScalaKryo" should {
     def test(obj: AnyRef): Unit = {
       val serializer = serialization.findSerializerFor(obj)
-      Console.println("Object of class " + obj.getClass.getName + " got serializer of class " + serializer.getClass.getName)
-      serializer.getClass.equals(classOf[KryoSerializer]) should be(true)
+      (serializer.getClass == classOf[KryoSerializer]) should be(true)
       // Check serialization/deserialization
       val serialized = serialization.serialize(obj)
       serialized.isSuccess should be(true)
 
       val deserialized = serialization.deserialize(serialized.get, obj.getClass)
       deserialized.isSuccess should be(true)
-      deserialized.get.equals(obj) should be(true)
+      (deserialized.get == obj) should be(true)
+      deserialized.get.getClass.isAssignableFrom(obj.getClass) should be(true)
+      obj.getClass.isAssignableFrom(deserialized.get.getClass) should be(true)
     }
 
     "handle Vectors" in {


### PR DESCRIPTION
They don't provide "genericBuilder" that builds ByteString but falls back to VectorBuilder (from immutable.IndexedSeq). Anyway, this serializer skips the builder and should perform better.

Also added the tests from @briantopping that also excercise the Vector serialization/deserialization 