### PR TITLE
Fix the AES encryption/decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The following options are available for configuring this serializer:
                 aes {
                     mode = "AES/CBC/PKCS5Padding"
                     key = j68KkRjq21ykRGAQ
+                    IV-length = 16
                     custom-key-class = "CustomAESKeyClass"
                 }
             }

--- a/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializerExtension.scala
+++ b/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializerExtension.scala
@@ -42,7 +42,7 @@ object KryoSerialization {
     val SerializerType: String = config.getString("akka.actor.kryo.type")
 
     val BufferSize: Int = config.getInt("akka.actor.kryo.buffer-size")
-    
+
     val MaxBufferSize: Int = config.getInt("akka.actor.kryo.max-buffer-size")
 
     val SerializerPoolSize: Int = config.getInt("akka.actor.kryo.serializer-pool-size")
@@ -68,6 +68,8 @@ object KryoSerialization {
     val AESKey = Try(config.getString(s"akka.actor.kryo.encryption.aes.key")).getOrElse("ThisIsASecretKey")
 
     val AESMode = Try(config.getString(s"akka.actor.kryo.encryption.aes.mode")).getOrElse("AES/CBC/PKCS5Padding")
+
+    val AESIVLength = Try(config.getInt(s"akka.actor.kryo.encryption.aes.IV-length")).getOrElse(16)
 
     val PostSerTransformations:  String = Try(config.getString("akka.actor.kryo.post-serialization-transformations")).getOrElse("off")
 


### PR DESCRIPTION
- it should generate new IV for each encrypted message

- put the IV as the prefix of the cyphertext so that
  it can later be decrypted by a different instance

- add optional configuration for the initialization
  vector length (IV-length), not all AES modes use 16
  bytes IV vector.

- Don't catch the specific decryption exceptions only
  to re-throw them as generic exceptions