### PR TITLE
IntelliJ suggested warnings fixed and unused imports removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ The following options are available for configuring this serializer:
             idstrategy = "incremental"
 
             # Define a default queue builder, by default ConcurrentLinkedQueue is used.
-            # To pass your own queue builder implement the trait KryoSerializer.QueueBuilder
+            # Create your own queue builder by implementing the trait QueueBuilder,
             # useful for paranoid GC users that want to use JCtools MpmcArrayQueue for example.
-            # If you pass a bounded queue make sure its capacity will be equal or greater than
-            # the concurrent threads your application will ever have running concurrently:
+            #
+            # If you pass a bounded queue make sure its capacity is equal or greater than the
+            # maximum concurrent remote dispatcher threads your application will ever have
+            # running; failing to do this will have a negative performance impact:
             #
             # custom-queue-builder = "a.b.c.KryoQueueBuilder"
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -40,7 +40,7 @@ akka {
 			# The serialization byte buffers are doubled as needed until they exceed maxBufferSize and an exception is thrown. Can be -1 for no maximum.   
 			max-buffer-size = -1
 
-			# Define a default queue builder, by default ConcurrentLinkedQueue is used.
+			# Define a custom queue builder, by default (unset) ConcurrentLinkedQueue is used.
 			# Look at the main documentation for a concrete example:
 			#
 			# custom-queue-builder = "a.b.c.KryoQueueBuilder"

--- a/src/main/scala/com/romix/scala/serialization/kryo/AkkaByteStringSerializer.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/AkkaByteStringSerializer.scala
@@ -18,13 +18,9 @@
 
 package com.romix.scala.serialization.kryo
 
-import scala.collection.Traversable
-
-import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.Serializer
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
 import akka.util.ByteString
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{Input, Output}
 
 /**
  * *
@@ -44,7 +40,7 @@ class AkkaByteStringSerializer() extends Serializer[ByteString] {
   override def write(kryo: Kryo, output: Output, obj: ByteString) = {
     val len = obj.size
     output.writeInt(len, true)
-    obj.foreach { output.writeByte(_) }
+    obj.foreach { output.writeByte }
   }
 }
 

--- a/src/main/scala/com/romix/scala/serialization/kryo/KryoClassResolver.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/KryoClassResolver.scala
@@ -19,13 +19,13 @@
 package com.romix.scala.serialization.kryo
 
 import com.esotericsoftware.kryo.util.DefaultClassResolver
-import com.esotericsoftware.kryo.Registration;
+import com.esotericsoftware.kryo.Registration
 
 class KryoClassResolver(val logImplicits: Boolean) extends DefaultClassResolver {
   override def registerImplicit(typ: Class[_]): Registration = {
-    if (kryo.isRegistrationRequired()) {
-      throw new IllegalArgumentException("Class is not registered: " + typ.getName()
-        + "\nNote: To register this class use: kryo.register(" + typ.getName() + ".class);")
+    if (kryo.isRegistrationRequired) {
+      throw new IllegalArgumentException("Class is not registered: " + typ.getName
+        + "\nNote: To register this class use: kryo.register(" + typ.getName + ".class);")
     }
     // registerInternal(new Registration(typ, kryo.getDefaultSerializer(typ), DefaultClassResolver.NAME))
     /* TODO: This does not work if sender and receiver are

--- a/src/main/scala/com/romix/scala/serialization/kryo/ScalaMapSerializers.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/ScalaMapSerializers.scala
@@ -109,11 +109,11 @@ class ScalaSortedMapSerializer() extends Serializer[SortedMap[_, _]] {
     implicit val mapOrdering = kryo.readClassAndObject(input).asInstanceOf[scala.math.Ordering[Any]]
     var coll: SortedMap[Any, Any] =
       try {
-        val constructor = class2constuctor.get(typ) getOrElse {
+        val constructor = class2constuctor.getOrElse(typ, {
           val constr = typ.getDeclaredConstructor(classOf[scala.math.Ordering[_]])
           class2constuctor += typ -> constr
           constr
-        }
+        })
         constructor.newInstance(mapOrdering).asInstanceOf[SortedMap[Any, Any]].empty
       } catch {
         case _: Throwable => kryo.newInstance(typ).asInstanceOf[SortedMap[Any, Any]].empty

--- a/src/main/scala/com/romix/scala/serialization/kryo/ScalaProductSerializers.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/ScalaProductSerializers.scala
@@ -18,14 +18,12 @@
 
 package com.romix.scala.serialization.kryo
 
-import scala.collection.Map
-import scala.collection.immutable
 import java.lang.reflect.Constructor
 
-import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.Serializer
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{Input, Output}
+
+import scala.collection.immutable
 
 /**
  * *
@@ -44,7 +42,7 @@ class ScalaProductSerializer(val kryo: Kryo) extends Serializer[Product] {
   var class2constuctor = immutable.Map[Class[_], Constructor[_]]()
 
   /**
-   * @param elementsCanBeNull False if all elements are not null. This saves 1 byte per element if elementClass is set. True if it
+   * @param _elementsCanBeNull False if all elements are not null. This saves 1 byte per element if elementClass is set. True if it
    *           is not known (default).
    */
   def setElementsCanBeNull(_elementsCanBeNull: Boolean) = {
@@ -52,12 +50,12 @@ class ScalaProductSerializer(val kryo: Kryo) extends Serializer[Product] {
   }
 
   /**
-   * @param elementClass The concrete class of each element. This saves 1-2 bytes per element. The serializer registered for the
+   * @param _elementClass The concrete class of each element. This saves 1-2 bytes per element. The serializer registered for the
    *           specified class will be used. Set to null if the class is not known or varies per element (default).
    */
   def setElementClass(_elementClass: Class[_]) = {
     elementClass = _elementClass
-    serializer = if (elementClass == null) null else kryo.getRegistration(elementClass).getSerializer()
+    serializer = if (elementClass == null) null else kryo.getRegistration(elementClass).getSerializer
   }
 
   /** Sets the number of objects in the collection. Saves 1-2 bytes. */
@@ -66,9 +64,9 @@ class ScalaProductSerializer(val kryo: Kryo) extends Serializer[Product] {
   }
 
   /**
-   * @param elementClass The concrete class of each element. This saves 1-2 bytes per element. Set to null if the class is not
+   * @param _elementClass The concrete class of each element. This saves 1-2 bytes per element. Set to null if the class is not
    *           known or varies per element (default).
-   * @param serializer The serializer to use for each element.
+   * @param _serializer The serializer to use for each element.
    */
   def setElementClass(_elementClass: Class[_], _serializer: Serializer[_]) = {
     elementClass = _elementClass
@@ -81,13 +79,12 @@ class ScalaProductSerializer(val kryo: Kryo) extends Serializer[Product] {
     val elems: Array[Any] = new Array(len)
 
     val constructor =
-      class2constuctor.get(typ) getOrElse
-        {
-          val constrs = typ.getDeclaredConstructors
-          val constr = constrs(0)
-          class2constuctor += typ -> constr
-          constr
-        }
+      class2constuctor.getOrElse(typ, {
+        val constrs = typ.getDeclaredConstructors
+        val constr = constrs(0)
+        class2constuctor += typ -> constr
+        constr
+      })
 
     if (len != 0) {
       if (serializer != null) {

--- a/src/main/scala/com/romix/scala/serialization/kryo/ScalaSetSerializers.scala
+++ b/src/main/scala/com/romix/scala/serialization/kryo/ScalaSetSerializers.scala
@@ -43,11 +43,11 @@ class ScalaImmutableSortedSetSerializer() extends Serializer[imSSet[_]] {
       implicit val setOrdering = kryo.readClassAndObject(input).asInstanceOf[scala.math.Ordering[Any]]
       try {
         val constructor =
-          class2constuctor.get(typ) getOrElse {
+          class2constuctor.getOrElse(typ, {
             val constr = typ.getDeclaredConstructor(classOf[scala.math.Ordering[_]])
             class2constuctor += typ -> constr
             constr
-          }
+          })
         constructor.newInstance(setOrdering).asInstanceOf[imSSet[Any]].empty
       } catch {
         case _: Throwable => kryo.newInstance(typ).asInstanceOf[imSSet[Any]].empty
@@ -110,11 +110,11 @@ class ScalaMutableSortedSetSerializer() extends Serializer[mSSet[_]] {
       implicit val setOrdering = kryo.readClassAndObject(input).asInstanceOf[scala.math.Ordering[Any]]
       try {
         val constructor =
-          class2constuctor.get(typ) getOrElse {
+          class2constuctor.getOrElse(typ, {
             val constr = typ.getDeclaredConstructor(classOf[scala.math.Ordering[_]])
             class2constuctor += typ -> constr
             constr
-          }
+          })
         constructor.newInstance(setOrdering).asInstanceOf[mSSet[Any]].empty
       } catch {
         case _: Throwable => kryo.newInstance(typ).asInstanceOf[mSSet[Any]].empty

--- a/src/test/scala/com/romix/akka/serialization/kryo/AkkaKryoCompressionTests.scala
+++ b/src/test/scala/com/romix/akka/serialization/kryo/AkkaKryoCompressionTests.scala
@@ -1,14 +1,12 @@
 package com.romix.akka.serialization.kryo
 
-import org.scalatest.FlatSpec
-
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.ActorSystem
 import akka.serialization._
 import com.typesafe.config.ConfigFactory
-import scala.collection.immutable.HashMap
-import scala.collection.immutable.TreeMap
-import scala.collection.mutable.AnyRefMap
-import scala.collection.mutable.LongMap
+import org.scalatest.FlatSpec
+
+import scala.collection.immutable.{HashMap, TreeMap}
+import scala.collection.mutable.{AnyRefMap, LongMap}
 
 class AkkaKryoCompressionTests extends FlatSpec {
   val defaultConfig = ConfigFactory.parseString("""
@@ -279,13 +277,13 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[HashMap[String,Any]] timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val atm = (List.fill(listLength) {
+      val atm = List.fill(listLength) {
         HashMap[String, Any](
           "foo" -> r.nextDouble,
           "bar" -> "foo,bar,baz",
           "baz" -> 124L,
           "hash" -> HashMap[Int, Int](r.nextInt -> r.nextInt, 5 -> 500, 10 -> r.nextInt))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(atm).getClass == classOf[KryoSerializer])
@@ -312,13 +310,13 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[TreeMap[String,Any]] timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val atm = (List.fill(listLength) {
+      val atm = List.fill(listLength) {
         TreeMap[String, Any](
           "foo" -> r.nextDouble,
           "bar" -> "foo,bar,baz",
           "baz" -> 124L,
           "hash" -> HashMap[Int, Int](r.nextInt -> r.nextInt, 5 -> 500, 10 -> r.nextInt))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(atm).getClass == classOf[KryoSerializer])
@@ -348,13 +346,13 @@ class AkkaKryoCompressionTests extends FlatSpec {
       val listLength = 500
 
       val r = new scala.util.Random(0L)
-      val atm = (List.fill(listLength) {
+      val atm = List.fill(listLength) {
         LongMap[Any](
           1L -> r.nextDouble,
           2L -> "foo,bar,baz",
           3L -> 124L,
           4L -> HashMap[Int, Int](r.nextInt -> r.nextInt, 5 -> 500, 10 -> r.nextInt))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(atm).getClass == classOf[KryoSerializer])
@@ -384,13 +382,13 @@ class AkkaKryoCompressionTests extends FlatSpec {
         val listLength = 500
 
         val r = new scala.util.Random(0L)
-        val atm = (List.fill(listLength) {
+        val atm = List.fill(listLength) {
           AnyRefMap[String, Any](
             "foo" -> r.nextDouble,
             "bar" -> "foo,bar,baz",
             "baz" -> 124L,
             "hash" -> HashMap[Int, Int](r.nextInt -> r.nextInt, 5 -> 500, 10 -> r.nextInt))
-        }).toArray
+        }.toArray
 
         assert(serialization.findSerializerFor(atm).getClass == classOf[KryoSerializer])
 
@@ -414,13 +412,13 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[mutable.HashMap[String,Any]] timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val atm = (List.fill(listLength) {
+      val atm = List.fill(listLength) {
         scala.collection.mutable.HashMap[String, Any](
           "foo" -> r.nextDouble,
           "bar" -> "foo,bar,baz",
           "baz" -> 124L,
           "hash" -> HashMap[Int, Int](r.nextInt -> r.nextInt, 5 -> 500, 10 -> r.nextInt))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(atm).getClass == classOf[KryoSerializer])
@@ -450,13 +448,13 @@ class AkkaKryoCompressionTests extends FlatSpec {
       val listLength = 500
 
       val r = new scala.util.Random(0L)
-      val atm = (List.fill(listLength) {
+      val atm = List.fill(listLength) {
         LongMap[Any](
           1L -> r.nextDouble,
           2L -> "foo,bar,baz",
           3L -> 124L,
           4L -> HashMap[Int, Int](r.nextInt -> r.nextInt, 5 -> 500, 10 -> r.nextInt))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(atm).getClass == classOf[KryoSerializer])
@@ -484,10 +482,10 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[immutable.HashSet[String]] timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val orig = (List.fill(listLength) {
+      val orig = List.fill(listLength) {
         scala.collection.immutable.HashSet[String](
           "foo", "bar", "foo,bar,baz", "baz", r.nextString(10))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(orig).getClass == classOf[KryoSerializer])
@@ -514,10 +512,10 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[immutable.TreeSet[String]] timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val orig = (List.fill(listLength) {
+      val orig = List.fill(listLength) {
         scala.collection.immutable.TreeSet[String](
           "foo", "bar", "foo,bar,baz", "baz", r.nextString(10))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(orig).getClass == classOf[KryoSerializer])
@@ -544,11 +542,11 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[immutable.BitSet timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val orig = (List.fill(listLength) {
+      val orig = List.fill(listLength) {
         scala.collection.immutable.BitSet(
-          1, 4, r.nextInt().abs % 32, r.nextInt().abs % 64, r.nextInt().abs % 64, r.nextInt().abs % 128 , r.nextInt().abs % 128,r.nextInt().abs % 256
+          1, 4, r.nextInt().abs % 32, r.nextInt().abs % 64, r.nextInt().abs % 64, r.nextInt().abs % 128, r.nextInt().abs % 128, r.nextInt().abs % 256
         )
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(orig).getClass == classOf[KryoSerializer])
@@ -575,10 +573,10 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[mutable.HashSet[String]] timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val orig = (List.fill(listLength) {
+      val orig = List.fill(listLength) {
         scala.collection.mutable.HashSet[String](
           "foo", "bar", "foo,bar,baz", "baz", r.nextString(10))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(orig).getClass == classOf[KryoSerializer])
@@ -605,10 +603,10 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[mutable.TreeSet[String]] timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val orig = (List.fill(listLength) {
+      val orig = List.fill(listLength) {
         scala.collection.mutable.TreeSet[String](
           "foo", "bar", "foo,bar,baz", "baz", r.nextString(10))
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(orig).getClass == classOf[KryoSerializer])
@@ -635,11 +633,11 @@ class AkkaKryoCompressionTests extends FlatSpec {
 
     it should "serialize and deserialize Array[mutable.BitSet timings (with compression)" in {
       val r = new scala.util.Random(0L)
-      val orig = (List.fill(listLength) {
+      val orig = List.fill(listLength) {
         scala.collection.mutable.BitSet(
-          1, 4, r.nextInt().abs % 32, r.nextInt().abs % 64, r.nextInt().abs % 64, r.nextInt().abs % 128 , r.nextInt().abs % 128,r.nextInt().abs % 256
+          1, 4, r.nextInt().abs % 32, r.nextInt().abs % 64, r.nextInt().abs % 64, r.nextInt().abs % 128, r.nextInt().abs % 128, r.nextInt().abs % 256
         )
-      }).toArray
+      }.toArray
 
       if (systemName != "Java")
         assert(serialization.findSerializerFor(orig).getClass == classOf[KryoSerializer])

--- a/src/test/scala/com/romix/akka/serialization/kryo/AkkaKryoCryptoWithCustomKeyTests.scala
+++ b/src/test/scala/com/romix/akka/serialization/kryo/AkkaKryoCryptoWithCustomKeyTests.scala
@@ -18,13 +18,12 @@ class AkkaKryoCryptoWithCustomKeyTests extends FlatSpec {
     val serialization = SerializationExtension(system)
 
     s"$systemName" should "read the aes key from the custom class specified" in {
-      val atm = (List {
+      val atm = List {
         AnyRefMap[String, Any](
           "foo" -> "foo",
           "bar" -> "foo,bar,baz",
           "baz" -> 124L)
-      }).toArray
-
+      }.toArray
 
       val serializer = serialization.findSerializerFor(atm)
       assert(serializer.isInstanceOf[KryoSerializer])

--- a/src/test/scala/com/romix/akka/serialization/kryo/AkkaKryoSerializationTests.scala
+++ b/src/test/scala/com/romix/akka/serialization/kryo/AkkaKryoSerializationTests.scala
@@ -16,19 +16,15 @@ limitations under the License.
 
 package com.romix.akka.serialization.kryo
 
+import akka.actor.{ActorRef, ActorSystem}
+import akka.serialization.{Serialization, _}
+import com.esotericsoftware.minlog.Log
+import com.typesafe.config.ConfigFactory
 import org.scalatest._
 
-import akka.actor.{ ActorRef, ActorSystem }
-import akka.serialization._
-import com.typesafe.config.ConfigFactory
-import akka.serialization.Serialization
-import scala.collection.immutable.TreeMap
-import scala.collection.immutable.HashMap
-import com.esotericsoftware.minlog.Log
-
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class AkkaKryoSerializationTests extends FlatSpec with Matchers {
 
@@ -198,7 +194,7 @@ class AkkaKryoSerializationTests extends FlatSpec with Matchers {
     deserialized.isSuccess should be(true)
 
     deserialized.get.equals(obj) should be(true)
-    serialized.get.size
+    serialized.get.length
   }
 
   it should "produce smaller serialized List representation when compression is enabled" in {

--- a/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
+++ b/src/test/scala/com/romix/akka/serialization/kryo/ByteStringTest.scala
@@ -3,10 +3,8 @@ package com.romix.akka.serialization.kryo
 import akka.actor.ActorSystem
 import akka.serialization.SerializationExtension
 import akka.util.ByteString
-import com.esotericsoftware.kryo.util.{DefaultClassResolver, DefaultStreamFactory, ListReferenceResolver}
-import com.romix.scala.serialization.kryo.{ScalaKryo, SpecCase}
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{WordSpecLike, Matchers, FlatSpec, Outcome}
+import org.scalatest.{Matchers, WordSpecLike}
 
 class ByteStringTest extends WordSpecLike with Matchers {
   val system = ActorSystem("example", ConfigFactory.parseString(

--- a/src/test/scala/com/romix/scala/serialization/kryo/EnumerationSerializationTest.scala
+++ b/src/test/scala/com/romix/scala/serialization/kryo/EnumerationSerializationTest.scala
@@ -2,18 +2,15 @@
 package com.romix.scala.serialization.kryo
 
 import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.Serializer
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
-import com.romix.scala.serialization.kryo._
+import com.esotericsoftware.kryo.io.{Input, Output}
 
 /** @author romix */
 // @Ignore
 class EnumarationSerializationTest extends SpecCase {
 
   "Enumerations" should "serialize and deseialize" in {
-    import WeekDay._
     import Time._
+    import WeekDay._
     kryo.setRegistrationRequired(false)
     kryo.addDefaultSerializer(classOf[scala.Enumeration#Value], classOf[EnumerationSerializer])
     kryo.register(Class.forName("scala.Enumeration$Val"))

--- a/src/test/scala/com/romix/scala/serialization/kryo/MapSerializerTest.scala
+++ b/src/test/scala/com/romix/scala/serialization/kryo/MapSerializerTest.scala
@@ -1,22 +1,13 @@
 package com.romix.scala.serialization.kryo
 
-import java.util.Arrays;
-import java.util.HashMap
-import java.util.Random
-import java.util.TreeMap
+import java.util.{HashMap, Random, TreeMap}
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.immutable.Map
-import scala.collection.immutable.Set
-import scala.collection.immutable.Vector
-
 import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.Serializer
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
+import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.serializers.MapSerializer
 
-import com.romix.scala.serialization.kryo._
+import scala.collection.immutable.{Map, Set, Vector}
 
 class MapSerializerTest extends SpecCase {
 
@@ -190,9 +181,9 @@ class MapSerializerTest extends SpecCase {
 
     0 until hugeCollectionSize foreach { case i => map1 += ("k" + i) }
 
-    val map2 = map1 + ("Moscow")
-    val map3 = map2 + ("Berlin")
-    val map4 = map3 + ("Germany") + ("Russia")
+    val map2 = map1 + "Moscow"
+    val map3 = map2 + "Berlin"
+    val map4 = map3 + "Germany" + "Russia"
     roundTrip(52, map1)
     roundTrip(35, map2)
     roundTrip(35, map3)
@@ -272,7 +263,7 @@ class MapSerializerTest extends SpecCase {
     kryo.writeClassAndObject(output, map)
     output.close()
 
-    val input = new Input(output.toBytes())
+    val input = new Input(output.toBytes)
     val deserialized = kryo.readClassAndObject(input)
     input.close()
 

--- a/src/test/scala/com/romix/scala/serialization/kryo/SpecCase.scala
+++ b/src/test/scala/com/romix/scala/serialization/kryo/SpecCase.scala
@@ -1,17 +1,11 @@
 package com.romix.scala.serialization.kryo
 
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.Serializer
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
-
-import com.esotericsoftware.kryo.ReferenceResolver
+import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.util.MapReferenceResolver
 import org.objenesis.strategy.StdInstantiatorStrategy
-
 import org.scalatest.FlatSpec
 
 abstract class SpecCase extends FlatSpec {
@@ -28,16 +22,16 @@ abstract class SpecCase extends FlatSpec {
   }
 
   def roundTrip[T](length: Int, obj: T): T = {
-    val outStream = new ByteArrayOutputStream();
+    val outStream = new ByteArrayOutputStream()
     val output = new Output(outStream, 4096)
     kryo.writeClassAndObject(output, obj)
     output.flush()
 
-    val input = new Input(new ByteArrayInputStream(outStream.toByteArray()), 4096);
-    val obj1 = kryo.readClassAndObject(input);
+    val input = new Input(new ByteArrayInputStream(outStream.toByteArray), 4096)
+    val obj1 = kryo.readClassAndObject(input)
 
-    assert(obj == obj1);
+    assert(obj == obj1)
 
-    obj1.asInstanceOf[T];
+    obj1.asInstanceOf[T]
   }
 }

--- a/src/test/scala/com/romix/scala/serialization/kryo/TupleSerializationTest.scala
+++ b/src/test/scala/com/romix/scala/serialization/kryo/TupleSerializationTest.scala
@@ -1,18 +1,6 @@
 
 package com.romix.scala.serialization.kryo
 
-import java.lang.reflect.TypeVariable;
-import java.util.Arrays;
-
-import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.Serializer
-import com.esotericsoftware.kryo.io.Input
-import com.esotericsoftware.kryo.io.Output
-import com.esotericsoftware.kryo.serializers.MapSerializer
-import com.romix.scala.serialization.kryo._
-
-//import com.romix.akka.serialization.kryo.KryoTestCase
-
 /** @author romix */
 // @Ignore
 class TupleSerializationTest extends SpecCase {


### PR DESCRIPTION
@romix @luben

**The following was done:**
-  Most IntelliJ warning suggested solutions applied (only for trivial cases)
- Unused imports removed.
- Small documentation fixed.

**Functional changes or side effects?** None that I could see.
**Formatting changes?** None

All tests were ran and passed, inside IntelliJ these tests usually take 1m49s but strangely is taking now 1m46s, the only thing that comes to mind is "`get(...) getOrElse(...)`" vs "`getOrElse(...)`" calls to make a difference, maybe is only my PC.