### PR TITLE
Build for Scala-2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ How to use this library in your project
 
 We provide several versions of the libraray:
 
-* v0.5.0 is build against Akka-2.4 and Kryo-4.0 and is available for Scala-2.11
-  and will be made available for Scala-2.12 when it is released
+* v0.5.1 is build against Akka-2.4 and Kryo-4.0 and is available for Scala-2.11 and Scala-2.12
 * v0.4.2 is build against Akka-2.4 and Kryo-3.0 and is available for Scala-2.11
 * v0.3.3 is build against Akka-2.3 and in available for Scala-2.10 and 2.11
 
@@ -33,7 +32,7 @@ To use this serializer, you need to do two things:
 
 * Include a dependency on this library into your project:
 
-    `libraryDependencies += "com.github.romix.akka" %% "akka-kryo-serialization" % "0.5.0"`
+    `libraryDependencies += "com.github.romix.akka" %% "akka-kryo-serialization" % "0.5.1"`
 
   or if you need Kryo-3.0 compatibility:
 
@@ -67,7 +66,7 @@ To use the official release of akka-kryo-serialization, please use the following
     <dependency>
         <groupId>com.github.romix.akka</groupId>
         <artifactId>akka-kryo-serialization_2.11</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
     </dependency>
 ```
 
@@ -83,13 +82,13 @@ If you want to test the latest snapshot of this library, please use the followin
     <dependency>
        <groupId>com.github.romix.akka</groupId>
        <artifactId>akka-kryo-serialization_2.11</artifactId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.5.2-SNAPSHOT</version>
     </dependency>
 ```
 
 For your SBT project files, you can use the following coordinates:
 
-    "com.github.romix.akka" %% "akka-kryo-serialization" % "0.5.0"
+    "com.github.romix.akka" %% "akka-kryo-serialization" % "0.5.1"
 
 or
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,7 +23,7 @@ object Build extends sbt.Build {
   lazy val typesafe = "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   lazy val typesafeSnapshot = "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
   lazy val sonatypeSnapshot = "Sonatype Snapshots Repository" at "https://oss.sonatype.org/content/repositories/snapshots/"
-  lazy val akkaVersion = "2.4.11"
+  lazy val akkaVersion = "2.4.12"
 
   lazy val root = Project(id = "akka-kryo-serialization", base = file(".")).settings(
 
@@ -32,8 +32,8 @@ object Build extends sbt.Build {
     resolvers += typesafeSnapshot,
     resolvers += sonatypeSnapshot,
     // publishArtifact in packageDoc := false,
-    scalaVersion := "2.11.8",
-    crossScalaVersions := Seq(scalaVersion.value),
+    scalaVersion := "2.12.0",
+    crossScalaVersions := Seq(scalaVersion.value, "2.11.8"),
     libraryDependencies += "com.typesafe.akka" %% "akka-remote" % akkaVersion,
     libraryDependencies += "com.esotericsoftware" % "kryo" % "4.0.0",
     libraryDependencies += "net.jpountz.lz4" % "lz4" % "1.3.0",
@@ -50,9 +50,12 @@ object Build extends sbt.Build {
       "-unchecked",
       "-deprecation",
       "-language:existentials",
-      "-optimise",
       "-Xlog-reflective-calls"
     ),
+
+    scalacOptions += scalaVersion.map { sv: String =>
+      if (sv.startsWith("2.11")) "-optimise" else "-opt:l:project"
+    }.value,
 
     //Enabling hardware AES support if available
     javaOptions in run += "-XX:+UseAES -XX:+UseAESIntrinsics",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.13

--- a/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializer.scala
+++ b/src/main/scala/com/romix/akka/serialization/kryo/KryoSerializer.scala
@@ -37,7 +37,7 @@ import com.romix.scala.serialization.kryo.{ScalaKryo, _}
 import net.jpountz.lz4.LZ4Factory
 import org.objenesis.strategy.StdInstantiatorStrategy
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuilder
 import scala.util.{Failure, Success, Try}
 
@@ -432,7 +432,7 @@ class KryoSerializer(val system: ExtendedActorSystem) extends Serializer {
         }
       }
 
-      for (classname <- classnames) {
+      for (classname <- classnames.asScala) {
         // Load class
         system.dynamicAccess.getClassFor[AnyRef](classname) match {
           case Success(clazz) => kryo.register(clazz)

--- a/src/test/scala/com/romix/scala/serialization/kryo/MapSerializerTest.scala
+++ b/src/test/scala/com/romix/scala/serialization/kryo/MapSerializerTest.scala
@@ -60,6 +60,7 @@ class MapSerializerTest extends SpecCase {
 
   it should "roundtrip muttable AnyRefMap" in {
     kryo.setRegistrationRequired(false)
+    kryo.addDefaultSerializer(classOf[scala.collection.mutable.AnyRefMap[_,_]], classOf[ScalaMutableMapSerializer])
     kryo.register(classOf[scala.collection.mutable.AnyRefMap[AnyRef, Any]], 3040)
 
     var map1 = scala.collection.mutable.AnyRefMap[String, String]()
@@ -77,6 +78,7 @@ class MapSerializerTest extends SpecCase {
 
   it should "roundtrip muttable LongMap" in {
     kryo.setRegistrationRequired(false)
+    kryo.addDefaultSerializer(classOf[scala.collection.mutable.LongMap[_]], classOf[ScalaMutableMapSerializer])
     kryo.register(classOf[scala.collection.mutable.LongMap[Any]], 3041)
 
     var map1 = scala.collection.mutable.LongMap[String]()
@@ -94,6 +96,7 @@ class MapSerializerTest extends SpecCase {
 
   it should "roundtrip immuttable LongMap" in {
     kryo.setRegistrationRequired(false)
+    kryo.addDefaultSerializer(classOf[scala.collection.immutable.LongMap[_]], classOf[ScalaImmutableMapSerializer])
     kryo.register(classOf[scala.collection.immutable.LongMap[Any]], 3042)
 
     var map1 = scala.collection.immutable.LongMap[String]()


### PR DESCRIPTION
+ Fixes a few deprecation warnings and a test.
+ Use not the highest optimization level for scala-2.12 (-opt:l:classpath) in order to make the produced jar work with different minor versions  of the dependencies.
+ Addresses #105 