### PR TITLE
Correct copy-paste typo for `kryoAESKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ which has a string return type i.e.
 ```scala
 
     public string kryoAESKey(...); // for Java
-    def customize(...):String // for Scala
+    def kryoAESKey(...):String // for Scala
 ```
 
 An example of such a custom aes-key supplier class could be something like this:


### PR DESCRIPTION
There is an error in the readme, in the customKey creation, where the method signature sample was clearly a duplicate of the previous section on cusomt kryo init.

This fork was not tested, but I didn't change any code, only corrected the md file.